### PR TITLE
221024 Programmers Lv.2 두 큐의 합 같게 만들기 풀이

### DIFF
--- a/Inu/1024_Programmers_두_큐_합_같게_만들기.py
+++ b/Inu/1024_Programmers_두_큐_합_같게_만들기.py
@@ -1,0 +1,48 @@
+# python 3.8
+
+def solution(queue1:list, queue2:list) -> int:
+    """
+    Return minimum number of moving to make sum of both queue same
+
+    Args:
+        queue1 (list): queue1, length of queue1 is same with queue2
+        queue2 (list): queue2, length of queue2 is same with queue1
+
+    Returns:
+        int: minimum number of moving. 
+             if no answer, return -1
+    """
+    Q = queue1 + queue2                 # combine queues
+    q1_sum = sum(queue1)                    
+    q2_sum = sum(queue2)
+
+    if(q1_sum + q2_sum) % 2 != 0:       # if sum of queue is odd-number, there is no answer
+        return -1 
+
+    q1_s = 0                            # queue1[0]
+    q2_s = len(queue1)                  # queue2[0]
+    
+    answer = 0
+    while True:
+        if answer > len(Q) * 1.5:       # if loop for len(queue1) * 3, It considered every case. No answer
+            return -1
+        if q1_sum > q2_sum:             # sum of queue1 > queue2 = queue1.pop -> queue2
+            q1_sum -= Q[q1_s]
+            q2_sum += Q[q1_s]
+            q1_s = (q1_s + 1) % len(Q)  # update index
+            answer += 1
+        elif q1_sum < q2_sum:           # sum of queue2 > queue1 = queue2.pop -> queue1
+            q1_sum += Q[q2_s]
+            q2_sum -= Q[q2_s]
+            q2_s = (q2_s + 1) % len(Q)  # update index
+            answer += 1
+        else:
+            break
+    return answer
+
+
+queue1 = list(map(int, input().split()))
+queue2 = list(map(int, input().split()))
+
+print(solution(queue1, queue2))
+


### PR DESCRIPTION
## Problem Description
<br>
- Programmers Lv.2 두 큐 합 같게 만들기
- 길이가 같은 두 큐를 popleft-append를 통해 각 큐 요소의 합이 같도록 하는 최소 횟수를 구한다.

## Explain Process
<br>
- 두 큐 각각의 합이 같도록 움직임을 최소화하는 방법은 각 큐의 합을 기준으로 큰 쪽에서 popleft를 해 작은 쪽에 append하는 것이다.
- 두 큐를 하나로 합친 뒤 투포인터를 활용하여 각 큐의 합을 상징하는 `q1_sum` 과 `q2_sum` 에서 포인터가 가리키는 값을 더하고 빼면서 반복시켜 최소 횟수를 구하였다.

### Comment
- python list 기준(deque x)으로 풀었을 때 시간초과
- PEP8를 기반으로 작성